### PR TITLE
Patch 3

### DIFF
--- a/script.py
+++ b/script.py
@@ -188,6 +188,16 @@ for i, fp in enumerate(file_paths):
                 
         #delete object
         bpy.ops.object.delete() 
+        
+        #delete orphan meshes 
+        for block in bpy.data.meshes:
+            if block.users == 0:
+                bpy.data.meshes.remove(block)
+        
+        #delete orphan curves (text)
+        for block in bpy.data.curves:
+            if block.users == 0:
+                bpy.data.curves.remove(block)
 
 ########################################
 #        


### PR DESCRIPTION
Added two for loops at end of primary image creation loop to clean up orphaned meshes and text curves. During processing of large folders these were piling up and causing a much larger than normal amount of memory usage. Deleting the Object in the scene does not appear to delete the meshes and curves shown in the Outliner->Blender File view.